### PR TITLE
Friend logic

### DIFF
--- a/services/PostService.js
+++ b/services/PostService.js
@@ -65,9 +65,9 @@ module.exports = () => {
             return date.toISOString().substring(0, 10);
         },
         async ensureAudienceIsFriends(params) {
-            const freshUser = await US.getUserById(params.user._id);
+            params.user = await US.getUserById(params.user._id);
             return await Promise.all(params.audienceIds.map(async (id) => {
-                await FS.ensureFriends(freshUser, id);
+                await FS.ensureFriends(params.user, id);
             }));
         },
         async addPostToCollectors(params) {
@@ -114,9 +114,9 @@ module.exports = () => {
         },
         async fetchPost(params) {
             await PS.ensurePostIsInCollector(params);
-            const freshUser = await US.getUserById(params.user._id);
+            params.user = await US.getUserById(params.user._id);
             const post = await PostModel.findById(params.postId);
-            await FS.ensureFriends(freshUser, post.poster._id);
+            await FS.ensureFriends(params.user, post.poster._id);
             const preparedPost = await PS.getPostForDelivery(post, params);
             return preparedPost;
         },
@@ -126,16 +126,16 @@ module.exports = () => {
         },
         async fetchRawEnsuredPost(params) {
             await PS.ensurePostIsInCollector(params);
-            const freshUser = await US.getUserById(params.user._id);
+            params.user = await US.getUserById(params.user._id);
             const post = await PostModel.findById(params.postId);
-            await FS.ensureFriends(freshUser, post.poster);
+            await FS.ensureFriends(params.user, post.poster);
             return post;
         },
         async ensurePostIsForUser(params) {
             await PS.ensurePostIsInCollector(params);
-            const freshUser = await US.getUserById(params.user._id);
+            params.user = await US.getUserById(params.user._id);
             const post = await PostModel.findById(params.postId).lean();
-            await FS.ensureFriends(freshUser, post.poster);
+            await FS.ensureFriends(params.user, post.poster);
             return post;
         },
         async ensurePostOwner(postObj, userObj, _params) {
@@ -347,9 +347,9 @@ module.exports = () => {
         },
         // Will take either a username param or userId param
         async fetchUsersPosts(params) {
-            const freshUser = await US.getUserById(params.user._id);
+            params.user = await US.getUserById(params.user._id);
             const friendId = (params.userId) ? params.userId : await US.getUsersId(params);
-            await FS.ensureFriends(freshUser, friendId);
+            await FS.ensureFriends(params.user, friendId);
 
             // Filter variables must be supplied in the params
             params.filterVars = [friendId];


### PR DESCRIPTION
fix the following bugs:
- could confirm friend requests that were never actually sent
- passed stale user objects to fetchPost and fetchRawEnsuredPost
- removeFriend didn't remove friendId
